### PR TITLE
When using Rails, allow configuration to come from the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Added
+* When using Rails, add the ability to configure using environment variables (#5)
 
 ## 0.2.1 / 2019-11-27
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ NdrStats.configure(host: 'localhost', port: 9125)
 
 ### Rails
 
-When used in a Rails application, you can store configuration in `config/stats.yml`.
+When used in a Rails application, you have the option to auto-configure `NdrStats`.
+
+#### File-based
+
+Add configuration in `config/stats.yml`:
 
 ```yaml
 ---
@@ -40,8 +44,16 @@ host: localhost
 port: 9125
 ```
 
+#### Environment config
+
+Alternatively, you can use environment variables `NDR_STATS_{HOST,PORT,SYSTEM,STACK}` to provide config parameters.
+Environment variables override any file-based configuration that's also found.
+
+#### System / Stack
+
 It's additionally possible to specify `system` and `stack`, which will be automatically added as tags on all stats.
 If the host application's enclosing module responds to the `flavour` or `stack` methods, these will be used if not otherwise specified.
+
 
 ## Usage
 

--- a/lib/ndr_stats/railtie.rb
+++ b/lib/ndr_stats/railtie.rb
@@ -1,14 +1,37 @@
 module NdrStats
   # Behaviour that runs when this gem is used in the context of a Rail app.
   class Railtie < Rails::Railtie
+    class << self
+      def config_values
+        config_from_file.merge(config_from_env)
+      end
+
+      private
+
+      def config_from_file
+        config_file = Rails.root.join('config/stats.yml')
+        return {} unless File.exist?(config_file)
+
+        YAML.load_file(config_file).symbolize_keys
+      end
+
+      def config_from_env
+        config = {}
+
+        ENV.each do |key, value|
+          next unless key =~ /\ANDR_STATS_(.*)/
+
+          config[Regexp.last_match(1).downcase.to_sym] = value
+        end
+
+        config
+      end
+    end
+
     # Auto-configures NdrStats with config in the host app, if found.
     config.after_initialize do
-      config_file = Rails.root.join('config', 'stats.yml')
-      next unless File.exist?(config_file)
-
-      config = YAML.load_file(config_file).symbolize_keys.
-               slice(:host, :port, :system, :stack).
-               reject { |_, value| value.blank? }
+      config = Railtie.config_values.slice(:host, :port, :system, :stack)
+      next if config.empty?
 
       # Try and derive system/stack from applications that expose it:
       app_class = Rails.application.class


### PR DESCRIPTION
This PR fixes issue #5. 

When using Rails, it allows the `Railtie` to additionally source configuration values from `NDR_STATS_*` keys in the environment - either as an alternate method, or as an override mechanism.